### PR TITLE
Check if editor context is being used before destroying window.

### DIFF
--- a/src/windows/GraphWindow.cpp
+++ b/src/windows/GraphWindow.cpp
@@ -301,7 +301,13 @@ GraphWindow::~GraphWindow()
 
     _links.clear();
 
+    if (ed::GetCurrentEditor() == std::bit_cast<ed::EditorContext*>(_editor_ctx.get()))
+    {
+        ed::SetCurrentEditor(nullptr);
+    }
+
     ed::DestroyEditor(std::bit_cast<ed::EditorContext*>(_editor_ctx.get()));
+    _editor_ctx.reset();
 }
 
 void GraphWindow::SetCurrentGraph()


### PR DESCRIPTION
Closes #15